### PR TITLE
Persist Timer Acrros - Fixes #1

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,31 +1,49 @@
-import {useRef} from 'react';
+import {useState, useRef} from 'react';
 
 const App = () => {
-  const inputRef = useRef(null);
+  const timerRef = useRef(null);
 
-  const submit = () => {
-    console.log(inputRef.current);
-    console.log(inputRef.current.value);
-    inputRef.current.style.backgroundColor = "red";
-    inputRef.current.style.color = 'white';
-    inputRef.current.setAttribute('placeholder', 'updated...');
+  const [time, setTime] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+
+  const toggleTimer = () => {
+    if (isRunning) {
+      // Clear interval to stop the timer
+      clearInterval(timerRef.current)
+      timerRef.current = null;
+    }else{
+      // Start timer
+      timerRef.current = setInterval(() => {
+        setTime((prevTime) => prevTime + 1);
+      }, 1000)
+    }
+
+    setIsRunning(!isRunning);
   }
 
-  console.log(inputRef);
+  const reseTimer = () => {
+    clearInterval(timerRef.current);
+    setIsRunning(false);
+    setTime(0);
+    timerRef.current = null;
+  }
 
   return ( 
     <div className="max-w-md mx-auto mt-10 p-6 bg-gray-100 rounded-lg shadow-lg text-center">
-      <h2 className="text-2xl font-bold mb-4">UseRef Example</h2>
-
-      <input 
-        type="text"
-        placeholder="Type something...."
-        className="w-full p-2 border rounded-lg"
-        ref={inputRef}
-      />
-
-      <button onClick={submit} className="mt-2 bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-700">
-        Submit
+      <h2 className="text-4xl font-semibold mb-4">
+        ⌛Timer: {time}
+      </h2>
+      <button
+        onClick={toggleTimer}
+        className='mt-3 bg-green-500 text-white px-4 py-2 mr-3 rounded hover:bg-green-700'
+      >
+        {isRunning ? 'Pause' : 'Start'}
+      </button>
+      <button
+        onClick={reseTimer}
+        className='mt-3 bg-red-500 text-white px-4 py-2 rounded hover:bg-red-700'
+      >
+        Reset
       </button>
     </div>
    );


### PR DESCRIPTION
## Objectif

Ce projet montre **comment utiliser `useRef()` pour stocker des valeurs persistantes** (ici, l’ID du timer retourné par `setInterval`) **sans provoquer de re-render**.

 L’idée :

- Le **temps affiché** dans le navigateur est stocké dans un **state** (car il doit rafraîchir l’UI).
- L’**ID du timer** est stocké dans un **ref** (car il doit persister entre les rendus, mais sans re-render).